### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,13 @@ on:
       - 'README.md'
       - '.gitignore'
       - '.gitattributes'
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.gitattributes'
 
 jobs:
   build:


### PR DESCRIPTION
The season matching is 1 month ahead, leaving the earliest anime (usually a week or two) of each season in the previous season.

For consumers, the current behaviour would appear correct as the "Winter" season is media that airs between January and March, but that does not account for the edge cases like this.

`Youkai Watch Jam: Youkai Gakuen Y - N to no Souguu` started on December 27th 2019:

- `modb-kitsu` treats it as Fall 2019
- [`anilist`](https://anilist.co/anime/113472/Youkai-Watch-Jam-Youkai-Gakuen-Y--N-to-no-Souguu) treats it as Winter 2020
- [`kitsu`](https://kitsu.io/anime/youkai-watch-jam-youkai-gakuen-y-n-to-no-souguu) treats it as Winter 2020 
- [`myanimelist`](https://myanimelist.net/anime/40714/Youkai_Watch_Jam__Youkai_Gakuen_Y_-_N_to_no_Souguu) treats it as Winter 2020
- `notify` does not have the entry

Notify version of https://github.com/manami-project/modb-kitsu/pull/2 and https://github.com/manami-project/modb-anidb/pull/1